### PR TITLE
Added an itemTriggerQty setting

### DIFF
--- a/src/scripts/settlement-upgrade-tracker/scraper.ts
+++ b/src/scripts/settlement-upgrade-tracker/scraper.ts
@@ -90,8 +90,8 @@ export const scrapeInventoriesTable = async (claimId: string, opts?: ScraperSett
             delete inventories[storageId];
             continue;
         }
-        if (opts?.triggerItem && opts?.triggerSlot !== undefined) {
-            const hasTriggerItem = storageHasTriggerItem(storage.items, opts.triggerItem, opts.triggerSlot);
+        if (opts?.triggerItem) {
+            const hasTriggerItem = storageHasTriggerItem(storage.items, opts.triggerItem, opts.triggerSlot, opts.triggerItemQty);
             if ((opts.excludeTrigger && hasTriggerItem) || (opts.includeTrigger && !hasTriggerItem)) {
                 console.debug(`Excluding storage due to trigger item condition: ${storage.storageName}`);
                 delete inventories[storageId];
@@ -108,9 +108,12 @@ const storageIsStall = (storageName: string): boolean => {
     return storageName.endsWith(' Stall');
 }
 
-const storageHasTriggerItem = (items: StoredItem[], triggerItem: string, triggerSlot: number): boolean => {
+const storageHasTriggerItem = (items: StoredItem[], triggerItem: string, triggerSlot?: number, triggerItemQty?: number): boolean => {
+    if (triggerSlot === undefined) {
+        return items.some(item => item.name.toLowerCase() === triggerItem.toLowerCase() && triggerItemQty !== undefined && triggerItemQty === item.amount);
+    }
     // If slot is negative, check the last slot
-    if (triggerSlot < 0) return items[items.length - 1]?.name.toLowerCase() === triggerItem.toLowerCase();
+    if (triggerSlot < 0) return items[items.length - 1]?.name.toLowerCase() === triggerItem.toLowerCase() && triggerItemQty !== undefined && triggerItemQty === items[items.length - 1].amount;
     
-    return (items[triggerSlot]?.name ?? '').toLowerCase()  === triggerItem.toLowerCase();
+    return (items[triggerSlot]?.name ?? '').toLowerCase()  === triggerItem.toLowerCase() && triggerItemQty !== undefined && triggerItemQty === items[triggerSlot].amount;
 }

--- a/src/scripts/settlement-upgrade-tracker/types.ts
+++ b/src/scripts/settlement-upgrade-tracker/types.ts
@@ -71,6 +71,8 @@ export type ScraperSettings = {
     triggerItem?: string;
     /** Slot index of the item that triggers either inclusion or exclusion */
     triggerSlot?: number;
+    /** Quantity of the trigger item to check for. */
+    triggerItemQty?: number;
     /** If true, exclude items that contain the trigger item */
     excludeTrigger?: boolean;
     /** If true, include items that contain the trigger item */


### PR DESCRIPTION
Added an option to trigger off a specific number of trigger items.
This is because the inventory data we get is unreliable as to the order it returns items in. Sometimes cargo data is first and sometimes its last